### PR TITLE
clone uriBuilder to prevent transform changing prefix original uriBuilder

### DIFF
--- a/lib/custom/src/MW/View/Helper/Url/Typo3.php
+++ b/lib/custom/src/MW/View/Helper/Url/Typo3.php
@@ -39,7 +39,7 @@ class Typo3
 		parent::__construct( $view );
 
 		$this->prefix = $uriBuilder->getArgumentPrefix();
-		$this->uriBuilder = $uriBuilder;
+		$this->uriBuilder = clone $uriBuilder;
 		$this->fixed = $fixed;
 	}
 

--- a/lib/custom/tests/MW/View/Helper/Url/Typo3Test.php
+++ b/lib/custom/tests/MW/View/Helper/Url/Typo3Test.php
@@ -178,4 +178,18 @@ class Typo3Test extends \PHPUnit\Framework\TestCase
 		$config = array( 'namespace' => false );
 		$this->assertEquals( '', $object->transform( null, null, null, $params, [], $config ) );
 	}
+
+
+	public function testTransformUnchangedOriginalUriBuilder()
+	{
+		$mock = $this->getMockBuilder( 'TYPO3\\CMS\\Extbase\\Mvc\\Web\\Routing\\UriBuilder' )
+			->setMethods( array( 'reset') )->getMock();
+
+		$mock->expects( $this->once() )->method( 'reset' )->will( $this->returnValue( $mock ) );
+
+		$object = new \Aimeos\MW\View\Helper\Url\Typo3( $this->view, $mock, [] );
+
+		$mock->expects( $this->never() )->method( 'reset' );
+		$this->assertEquals( '', $object->transform( null, null, null, [], [], [] ) );
+	}
 }


### PR DESCRIPTION
As discussed in https://github.com/aimeos/aimeos-typo3/issues/71

Hope the Unittest is ok.