### PR TITLE
Add Scheme config option for https links

### DIFF
--- a/lib/custom/src/MW/View/Helper/Url/Typo3.php
+++ b/lib/custom/src/MW/View/Helper/Url/Typo3.php
@@ -82,6 +82,7 @@ class Typo3
 			->setTargetPageUid( $target )
 			->setSection( join( '/', $trailing ) )
 			->setCreateAbsoluteUri( $values['absoluteUri'] )
+			->setAbsoluteUriScheme( $values['scheme'] )
 			->setTargetPageType( $values['type'] )
 			->setUseCacheHash( $values['chash'] )
 			->setNoCache( $values['nocache'] )
@@ -112,6 +113,7 @@ class Typo3
 			'nocache' => false,
 			'chash' => false,
 			'format' => '',
+			'scheme' => null,
 			'type' => 0,
 		);
 
@@ -145,6 +147,10 @@ class Typo3
 
 		if( isset( $config['format'] ) ) {
 			$values['format'] = (string) $config['format'];
+		}
+		
+		if( isset( $config['scheme'] ) ) {
+			$values['scheme'] = (string) $config['scheme'];
 		}
 
 		return $values;

--- a/lib/custom/tests/MW/View/Helper/Url/UriBuilder
+++ b/lib/custom/tests/MW/View/Helper/Url/UriBuilder
@@ -54,6 +54,14 @@ class UriBuilder
 		return $this;
 	}
 
+	/**
+	 * @param string $scheme
+	 */
+	public function setAbsoluteUriScheme( $scheme )
+	{
+		return $this;
+	}
+
 	public function setArguments( $additional )
 	{
 		return $this;


### PR DESCRIPTION
When running a scheduler job from cron, http:// links are generated by default. This patch adds a parameter `scheme `to the `$config` array.

Usage example: `client/html/<clientname>/url/config/scheme = https`