### PR TITLE
Replace usage of ext:saltedpasswords with core

### DIFF
--- a/lib/custom/src/MShop/Context/Item/Typo3.php
+++ b/lib/custom/src/MShop/Context/Item/Typo3.php
@@ -37,10 +37,10 @@ class Typo3
 	/**
 	 * Sets the TYPO3 password hasher object
 	 *
-	 * @param \TYPO3\CMS\Saltedpasswords\Salt\SaltInterface $object
+	 * @param \TYPO3\CMS\Core\Crypto\PasswordHashing\PasswordHashInterface $object
 	 * @return \Aimeos\MShop\Context\Item\Iface Context item for chaining method calls
 	 */
-	public function setHasherTypo3( \TYPO3\CMS\Saltedpasswords\Salt\SaltInterface $object ) : \Aimeos\MShop\Context\Item\Iface
+	public function setHasherTypo3( \TYPO3\CMS\Core\Crypto\PasswordHashing\PasswordHashInterface $object ) : \Aimeos\MShop\Context\Item\Iface
 	{
 		$this->hasher = $object;
 		return $this;


### PR DESCRIPTION
https://docs.typo3.org/c/typo3/cms-core/master/en-us/Changelog/9.4/Deprecation-85833-ExtensionSaltedpasswordsMergedIntoCoreExtension.html