### PR TITLE
Take the page type into account for caching - Part 2

### DIFF
--- a/lib/custom/src/MW/Cache/Typo3.php
+++ b/lib/custom/src/MW/Cache/Typo3.php
@@ -35,7 +35,7 @@ class Typo3
 	public function __construct( array $config, \TYPO3\CMS\Core\Cache\Frontend\FrontendInterface $cache )
 	{
 		$this->prefix = ( isset( $config['siteid'] ) ? $config['siteid'] . '-' : '' );
-        $this->prefix .= ( isset( $config['pageType'] ) ? $config['pageType'] . '-' : '' );
+		$this->prefix .= ( isset( $config['pageType'] ) ? $config['pageType'] . '-' : '' );
 		$this->object = $cache;
 	}
 

--- a/lib/custom/src/MW/Cache/Typo3.php
+++ b/lib/custom/src/MW/Cache/Typo3.php
@@ -31,11 +31,11 @@ class Typo3
 	 *
 	 * @param array $config List of configuration values
 	 * @param \TYPO3\CMS\Core\Cache\Frontend\FrontendInterface $cache TYPO3 cache object
-	 * @deprecated 2022.01 Remove $config parameter and siteid prefix
 	 */
 	public function __construct( array $config, \TYPO3\CMS\Core\Cache\Frontend\FrontendInterface $cache )
 	{
 		$this->prefix = ( isset( $config['siteid'] ) ? $config['siteid'] . '-' : '' );
+        $this->prefix .= ( isset( $config['pageType'] ) ? $config['pageType'] . '-' : '' );
 		$this->object = $cache;
 	}
 


### PR DESCRIPTION
Hi everyone.

Please review, test and comment.  😃 

We add the retrieved page type to the caching proxy via constructor.
Then we add it to the caching key prefix via the `$config` array.

I'm extremely unsure about this one, because the  `$config` array was deprecated.

Tobi