### PR TITLE
Fix for "Scheduler E-Mails not being sent"

### DIFF
--- a/src/Base/Mail/Message/Typo3.php
+++ b/src/Base/Mail/Message/Typo3.php
@@ -198,7 +198,9 @@ class Typo3 implements \Aimeos\Base\Mail\Message\Iface
 	 */
 	public function send() : Iface
 	{
-		$this->object->send();
+		\TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(
+        		\TYPO3\CMS\Core\Mail\Mailer::class
+		)->send($this->object);
 		return $this;
 	}
 


### PR DESCRIPTION
Typo3 V14.3.2
Aimeos V26.7.1
Following error appears when executing Aimeos scheduler jobs related to mails. This fix seems to be working.

Core: Exception handler (WEB): Uncaught TYPO3 Exception: Call to undefined method TYPO3\CMS\Core\Mail\MailMessage::send() | Error thrown in file /.../vendor/aimeos/ai-typo3/src/Base/Mail/Message/Typo3.php in line 193.